### PR TITLE
Error checking for genesis block

### DIFF
--- a/core/block_pool_test.go
+++ b/core/block_pool_test.go
@@ -39,7 +39,8 @@ func (c MockConsensus) VerifyBlock(block *Block) error {
 
 func TestBlockPool(t *testing.T) {
 	storage, _ := storage.NewMemoryStorage()
-	bc, _ := NewBlockChain(0, storage)
+	bc, err := NewBlockChain(0, storage)
+	assert.NoError(t, err)
 	var cons MockConsensus
 	bc.SetConsensusHandler(cons)
 	pool := bc.bkPool
@@ -68,7 +69,7 @@ func TestBlockPool(t *testing.T) {
 	tx2.Sign(signature)
 	tx3 := NewTransaction(0, from, to, util.NewUint128FromInt(3), 3, TxPayloadBinaryType, []byte("nas"), TransactionGasPrice, TransactionGas)
 	tx3.Sign(signature)
-	err := bc.txPool.Push(tx1)
+	err = bc.txPool.Push(tx1)
 	assert.NoError(t, err)
 	err = bc.txPool.Push(tx2)
 	assert.NoError(t, err)

--- a/storage/disk_storage.go
+++ b/storage/disk_storage.go
@@ -47,7 +47,12 @@ func NewDiskStorage(path string) (*DiskStorage, error) {
 
 // Get return value to the key in Storage
 func (storage *DiskStorage) Get(key []byte) ([]byte, error) {
-	return storage.db.Get(key, nil)
+	value, err := storage.db.Get(key, nil)
+	if err != nil && err == leveldb.ErrNotFound {
+		return nil, ErrKeyNotFound
+	}
+
+	return value, err
 }
 
 // Put put the key-value entry to Storage


### PR DESCRIPTION
- `loadGenesisFromStorage` should return error if error is not `ErrKeyNotFound` so that `NewBlockChain` can exit gracefully. 
- `storage` should return same error `ErrKeyNotFound` for both `DiskStorage` and `MemoryStorage`