### PR TITLE
Fix build error when neb binary not exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ deploy-libs:
 build:
 	cd cmd/neb; go build $(LDFLAGS) -o ../../$(BINARY)-$(COMMIT)
 	cd cmd/crashreporter; go build $(LDFLAGS) -o ../../nebulas_crashreporter
-	rm $(BINARY)
+	[ -f "$(BINARY)" ] && rm -f $(BINARY)
 	ln -s $(BINARY)-$(COMMIT) $(BINARY)
 
 build-linux:


### PR DESCRIPTION
```
rm -v neb
rm: cannot remove 'neb': No such file or directory
Makefile:64: recipe for target 'build' failed
make: *** [build] Error 1
```