### PR TITLE
rollup.config.js: updated to new nomenclature so that rollup -c runs

### DIFF
--- a/cmd/console/neb.js/rollup.config.js
+++ b/cmd/console/neb.js/rollup.config.js
@@ -2,9 +2,13 @@ import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
 
 export default {
-  entry: './index.js',
-  dest: 'dist/neb-node.js',
-  format: 'cjs',
+  input: './index.js',
+
+  output: {
+    file: 'dist/neb-node.js',
+    format: 'cjs'
+  },
+
   plugins: [
 
     commonjs({
@@ -20,8 +24,8 @@ export default {
     }),
 
     nodeResolve({
-    jsnext: true,
-    main: false
+        jsnext: true,
+        main: false
     })
-]
+  ]
 };


### PR DESCRIPTION
The current version of rollup.config.js no longer works due to rollup
changing some config variable names. A few lines of code fixed it up.

Fixes #68