### PR TITLE
Fix value transfer issue during deploying new contracts

### DIFF
--- a/core/transaction_deploy_payload.go
+++ b/core/transaction_deploy_payload.go
@@ -134,6 +134,15 @@ func (payload *DeployPayload) Execute(limitedGas *util.Uint128, tx *Transaction,
 		return util.NewUint128(), "", err
 	}
 
+	// Transfer value to contract
+	if fromAcc, err := ws.GetOrCreateUserAccount(tx.from.address); err != nil {
+		return util.NewUint128(), "", err
+	} else if err := fromAcc.SubBalance(tx.value); err != nil {
+		return util.NewUint128(), "", err
+	} else if err := contract.AddBalance(tx.value); err != nil {
+		return util.NewUint128(), "", err
+	}
+
 	// Deploy and Init.
 	result, exeErr := engine.DeployAndInit(payload.Source, payload.SourceType, payload.Args)
 	gasCount := engine.ExecutionInstructions()


### PR DESCRIPTION
Analysis:
When deploying a new contract, the `from` and `to` address must be same.
But if the transfer `value` is greater than 0, which means the transaction
sender wants to transfer `value` coins into the new contract, then the transfer
cannot work.
That's because in fact the `value` coins are transfered from his accout and
back to his account again, instead of transfering to the new contract account.
    
Root cause:
The value transfer is not handled correctly for `deploy` type transaction.
    
Solution:
Transfer correct `value` from `from` account to the new contract account.