### PR TITLE
Fix value transfer issue during deploying new contracts(including test case fix)

### DIFF
--- a/core/transaction_deploy_payload.go
+++ b/core/transaction_deploy_payload.go
@@ -134,6 +134,15 @@ func (payload *DeployPayload) Execute(limitedGas *util.Uint128, tx *Transaction,
 		return util.NewUint128(), "", err
 	}
 
+	// Transfer value to contract
+	if fromAcc, err := ws.GetOrCreateUserAccount(tx.from.address); err != nil {
+		return util.NewUint128(), "", err
+	} else if err := fromAcc.SubBalance(tx.value); err != nil {
+		return util.NewUint128(), "", err
+	} else if err := contract.AddBalance(tx.value); err != nil {
+		return util.NewUint128(), "", err
+	}
+
 	// Deploy and Init.
 	result, exeErr := engine.DeployAndInit(payload.Source, payload.SourceType, payload.Args)
 	gasCount := engine.ExecutionInstructions()

--- a/core/transaction_test.go
+++ b/core/transaction_test.go
@@ -500,20 +500,22 @@ func TestTransaction_VerifyExecution(t *testing.T) {
 	assert.Equal(t, ErrInsufficientBalance, result.Err)
 	executionEqualBalanceTx.gasLimit = result.GasUsed
 	t.Log("gasUsed:", result.GasUsed)
-	coinbaseBalance, err = executionInsufficientBalanceTx.gasPrice.Mul(result.GasUsed)
+	coinbaseBalance, err = executionEqualBalanceTx.gasPrice.Mul(result.GasUsed)
 	assert.Nil(t, err)
 	executionEqualBalanceTx.value = balance
 	gasCost, err := executionEqualBalanceTx.gasPrice.Mul(result.GasUsed)
 	assert.Nil(t, err)
 	fromBalance, err := gasCost.Add(balance)
 	assert.Nil(t, err)
+	afterBalance, err = util.NewUint128FromString("0")
+	assert.Nil(t, err)
 	tests = append(tests, testTx{
 		name:            "execution equal fromBalance after execution tx",
 		tx:              executionEqualBalanceTx,
 		fromBalance:     fromBalance,
 		gasUsed:         result.GasUsed,
-		afterBalance:    balance,
-		toBalance:       balance,
+		afterBalance:    afterBalance,
+		toBalance:       afterBalance,
 		coinbaseBalance: coinbaseBalance,
 		wanted:          nil,
 		eventErr:        "",


### PR DESCRIPTION
Analysis:
When deploying a new contract, the `from` and `to` address must be same.
If the transfer `value` is greater than 0, which means the transaction
sender wants to transfer `value` coins into the new contract, then the transfer
cannot work, nothing is transfered.
That's because in fact the `value` coins are transfered from his accout and
back to his account again, instead of transfering to the new contract account.

Root cause:
The value transfer is not handled correctly for `deploy` type transaction.

Solution:
Transfer correct `value` from `from` account to the new contract account.

Signed-off-by: caiyesd <caiyesd@gmail.com>